### PR TITLE
Fix all the deprecated units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,62 @@
+# ---> Windows
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# ---> Linux
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# ---> Kate
+# Swap Files #
+.*.kate-swp
+.swp.*
+
+# ---> Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+.history/
+
+# ---> Nim
+nimcache/
+nimblecache/
+htmldocs/
+*_[0-9][0-9]*.nims
+
+# Binaries and Temp Files
+sha3

--- a/sha3.nim
+++ b/sha3.nim
@@ -116,7 +116,7 @@ proc sha3_update*(c: var SHA3, data: cstring|string|seq|uint8,
                   data_size: int) =
    for i in 0..<data_size:
       when data is cstring or data is string:
-         c.buffer[c.buffer_idx] = ord(data[i])
+         c.buffer[c.buffer_idx] = ord(data[i]).uint8
       elif data is seq:
          c.buffer[c.buffer_idx] = data[i]
       else:
@@ -258,14 +258,14 @@ when isMainModule:
       try:
          sha3_init(ktx, 16, "abc", 3)
          splt = split(f.readLine(), ':')
-         Aaa = cstring(repeatStr(parseInt(splt[0]), "abc"))
+         Aaa = cstring("abc".repeat(parseInt(splt[0])))
          for i in 0..high(Aaa):
             sha3_update(ktx, ($Aaa[i]).cstring, 1)
          assert($sha3_final(ktx) == toLowerAscii(splt[1]))
       except IOError: break
    close(f)
    assert(getSHA3("a", 16) == "9ead6b5332e658d12672d3ab0de17f12")
-   assert(getSHA3(nil, 16) == "1ac2d450fc3b4205d19da7bfca1b3751")
+   assert(getSHA3("", 16) == "1ac2d450fc3b4205d19da7bfca1b3751")
    assert(getSHA3("abc", 4) == "ab174f32")
    assert(getSHA3("The quick brown fox jumps over the lazy dog") == "b4f249b4f77c58df170aa4d1723db112")
 
@@ -339,9 +339,9 @@ when isMainModule:
          try:
             discard f.readLine()
             data = f.readLine()
-            data = hex2str(data[6..^0])
+            data = hex2str(data[6..^1])
             hash = f.readLine()
-            hash = hash[5..^0]
+            hash = hash[5..^1]
             assert(getSHA3(t[0], data) == hash)
             sha3_init(ctx, t[0])
             for i in 0..high(data):
@@ -356,9 +356,9 @@ when isMainModule:
          try:
             discard f.readLine()
             data = f.readLine()
-            data = hex2str(data[6..^0])
+            data = hex2str(data[6..^1])
             hash = f.readLine()
-            hash = hash[9..^0]
+            hash = hash[9..^1]
             assert(getSHA3(t[0], data) == hash)
             sha3_init(ctx, t[0])
             for i in 0..high(data):

--- a/sha3.nimble
+++ b/sha3.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.6"
+version       = "0.7"
 author        = "tankfeeder"
 description   = "sha3 library"
 license       = "CC0"


### PR DESCRIPTION
All the errors fixed here can be backtracked,
to some change made to the Nim compiler,
many years ago.

Example:
https://github.com/nim-lang/Nim/commit/3546ff88190640b83ace136a9e8abc46b7e1811e